### PR TITLE
fix(typing): Remove typing on class declaration

### DIFF
--- a/simple_analytics/admin.py
+++ b/simple_analytics/admin.py
@@ -4,7 +4,7 @@ from simple_analytics.models import VisitPerPage
 
 
 @admin.register(VisitPerPage)
-class PageAnalyticsAdmin(admin.ModelAdmin[VisitPerPage]):
+class PageAnalyticsAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     list_display = (
         "page",
         "method",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,11 +1,6 @@
 # Django test settings
 from pathlib import Path
 
-import django_stubs_ext
-
-django_stubs_ext.monkeypatch()
-
-
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = "django-insecure-tesitng-key"


### PR DESCRIPTION
- It makes things not work unless you run the monkeypatch on production
  which is not ideal. Until this can be ignored at runtime, the type
  error will be ignored.
