### PR TITLE
Ignore query params for path

### DIFF
--- a/simple_analytics/middleware.py
+++ b/simple_analytics/middleware.py
@@ -27,7 +27,7 @@ def normalize_request_path(request_path: str) -> str:
 def process_analytics(request: HttpRequest, **kwargs: Any) -> VisitPerPage:
     analytics, created = VisitPerPage.objects.get_or_create(
         date=dt.date.today(),
-        page=request.get_full_path_info(),
+        page=request.path,
         method=request.method or "",
         username=str(request.user),
         origin=request.META.get("HTTP_REFERER", ""),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,11 +51,11 @@ def get(client, url):
     def _(
         url_name: str,
         expected_status_code: int = 200,
-        follow: bool = True,
-        headers: Optional[dict] = None,
+        request_kwargs: Optional[dict] = None,
         **url_kwargs,
     ):
-        response = client.get(url(url_name, **url_kwargs), follow=follow, **(headers or {}))
+        url_under_test = url(url_name, **url_kwargs)
+        response = client.get(url_under_test, **(request_kwargs or {}))
         assert response.status_code == expected_status_code
         return response
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import datetime as dt
-from typing import Optional
 
 import pytest
 import time_machine
@@ -44,22 +43,6 @@ def url():
 @pytest.fixture
 def login(client, user):
     client.force_login(user)
-
-
-@pytest.fixture
-def get(client, url):
-    def _(
-        url_name: str,
-        expected_status_code: int = 200,
-        request_kwargs: Optional[dict] = None,
-        **url_kwargs,
-    ):
-        url_under_test = url(url_name, **url_kwargs)
-        response = client.get(url_under_test, **(request_kwargs or {}))
-        assert response.status_code == expected_status_code
-        return response
-
-    return _
 
 
 @pytest.fixture

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -35,6 +35,16 @@ def test_analytics_middleware_creates_objects_with_status_not_found(
     assert first_row_analytics().exists == status
 
 
+@pytest.mark.urls("tests.urls")
+@pytest.mark.django_db
+def test_analytics_middleware_ignores_query_params(get, first_row_analytics):
+    resp = get(
+        "test-url", request_kwargs={"data": {"param1": "AAAAAAAAAAA", "param2": "OOOOOOOOOOOO"}}
+    )
+    assert resp.request.get("QUERY_STRING") != ""
+    assert first_row_analytics().page == "/test-url-path/"
+
+
 @pytest.mark.parametrize(
     "ignored_path",
     [
@@ -99,5 +109,5 @@ def test_process_analytics_records_field(
 def test_process_analytics_records_logged_in_users_records_fields(
     login, get, analytics_middleware, first_row_analytics, field, expected_value
 ):
-    get("test-url", headers={"HTTP_REFERER": test_origin})
+    get("test-url", request_kwargs={"headers": {"HTTP_REFERER": test_origin}})
     assert getattr(first_row_analytics(), field) == expected_value


### PR DESCRIPTION
- fix(middleware): Use path instead of full path
- test(middleware): Test for ensuring query params are ignored
